### PR TITLE
ls: improvements

### DIFF
--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -69,7 +69,9 @@ fn ls() -> Result<(), String> {
 	entries.sort_by_key(|entry| entry.path());
 
 	for entry in entries {
-		println!("{}", entry.path().display());
+		let path = entry.path();
+		let display_path = path.strip_prefix("./").unwrap_or(&path);
+		println!("{}", display_path.display());
 	}
 
 	Ok(())

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -18,7 +18,7 @@ pub fn exec_builtin(cmd: &str, args: &[&str]) -> Result<(), String> {
 			Ok(())
 		}
 		"ls" => {
-			ls()?;
+			ls(args)?;
 			Ok(())
 		}
 		"help" => {
@@ -56,11 +56,10 @@ fn pwd() -> Result<(), String> {
 	Ok(())
 }
 
-// TODO: improve output - prefixed with `./`
 // https://doc.rust-lang.org/std/fs/fn.read_dir.html
-fn ls() -> Result<(), String> {
+fn ls(args: &[&str]) -> Result<(), String> {
 	// Collect all items in the current directory with read_dir iterator
-	let mut entries: Vec<_> = std::fs::read_dir(".")
+	let mut entries: Vec<_> = std::fs::read_dir(args.first().unwrap_or(&"."))
 		.map_err(|e| format!("ls: {e}"))?
 		.collect::<Result<Vec<_>, _>>()
 		.map_err(|e| format!("ls: {e}"))?;


### PR DESCRIPTION
- removes prefix from outputs
- accepts argument that will be used as the path to list