### PR TITLE
ls: fix --help handling to hide additional error message

### DIFF
--- a/commands/ls/Cargo.toml
+++ b/commands/ls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shell-ls"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
should hide the additional error "Invalid arguments, please try again" that incorrectly appears when using `--help`.